### PR TITLE
Add Todo page and rename site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LEXIA会計システム
+# LEXIA management system
 
 *[v0.dev](https://v0.dev) デプロイメントと自動同期*
 

--- a/app/kgi-kpi/page.tsx
+++ b/app/kgi-kpi/page.tsx
@@ -29,9 +29,7 @@ import { useEffect, useMemo, useState } from "react"
 import { supabase, TABLE_NAME, PROJECTS_TABLE } from "@/lib/supabase"
 import { formatNumber } from "@/lib/utils"
 import { RecordItem } from "@/components/vault-table"
-import { AddProjectDialog, NewProject } from "@/components/add-project-dialog"
-import { EditProjectDialog } from "@/components/edit-project-dialog"
-import { ProjectProgressTable, ProjectProgressRecord } from "@/components/project-progress-table"
+import { ProjectProgressRecord } from "@/components/project-progress-table"
 
 export default function KgiKpiPage() {
   const [records, setRecords] = useState<RecordItem[]>([])
@@ -54,64 +52,6 @@ export default function KgiKpiPage() {
       .catch(() => setProjects([]))
   }, [])
 
-  const handleAddProject = async (project: NewProject) => {
-    const nextOrder =
-      projects.reduce((max, p) => Math.max(max, p.sort_order), -1) + 1
-    const { data, error } = await supabase
-      .from(PROJECTS_TABLE)
-      .insert({ ...project, sort_order: nextOrder })
-      .select()
-      .single()
-
-    if (error) {
-      console.error('Insert project error:', error.message)
-      return
-    }
-    if (data) setProjects((prev) => [...prev, data as ProjectProgressRecord])
-  }
-
-  const handleUpdateProject = async (project: ProjectProgressRecord) => {
-    const { data } = await supabase
-      .from(PROJECTS_TABLE)
-      .update(project)
-      .eq('id', project.id)
-      .select()
-      .single()
-    if (data)
-      setProjects((prev) =>
-        prev.map((p) => (p.id === project.id ? (data as ProjectProgressRecord) : p))
-      )
-  }
-
-  const handleDeleteProject = async (id: string) => {
-    await supabase.from(PROJECTS_TABLE).delete().eq('id', id)
-    setProjects((prev) => prev.filter((p) => p.id !== id))
-  }
-
-  const moveProject = async (id: string, direction: "up" | "down") => {
-    let updates: { id: string; sort_order: number }[] = []
-    setProjects((prev) => {
-      const idx = prev.findIndex((p) => p.id === id)
-      if (idx === -1) return prev
-      const swapIdx = direction === "up" ? idx - 1 : idx + 1
-      if (swapIdx < 0 || swapIdx >= prev.length) return prev
-      const newProjects = [...prev]
-      ;[newProjects[idx], newProjects[swapIdx]] = [
-        newProjects[swapIdx],
-        newProjects[idx],
-      ]
-      newProjects.forEach((p, i) => {
-        p.sort_order = i
-      })
-      updates = newProjects.map((p) => ({ id: p.id, sort_order: p.sort_order }))
-      return newProjects
-    })
-    if (updates.length) {
-      await supabase.from(PROJECTS_TABLE).upsert(updates)
-    }
-  }
-
-  const [editing, setEditing] = useState<ProjectProgressRecord | null>(null)
 
   const kgiTarget = 1500000
 
@@ -416,21 +356,7 @@ export default function KgiKpiPage() {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader className="flex items-center justify-between">
-            <CardTitle>案件進捗・ステータス一覧</CardTitle>
-            <AddProjectDialog onAdd={handleAddProject} className="ml-auto" />
-          </CardHeader>
-          <CardContent>
-            <ProjectProgressTable
-              projects={projects}
-              onEdit={(p) => setEditing(p)}
-              onDelete={handleDeleteProject}
-              onUpdate={handleUpdateProject}
-              onMove={(id, dir) => moveProject(id, dir)}
-            />
-          </CardContent>
-        </Card>
+
 
         <div className="grid gap-4 md:grid-cols-2">
           {metrics.map((m) => (
@@ -471,17 +397,7 @@ export default function KgiKpiPage() {
           </CardContent>
         </Card>
       </div>
-      {editing && (
-        <EditProjectDialog
-          project={editing}
-          onEdit={(p) => {
-            handleUpdateProject(p)
-            setEditing(null)
-          }}
-          open={true}
-          onOpenChange={(v) => !v && setEditing(null)}
-        />
-      )}
+      {}
     </DashboardLayout>
   )
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
-        <h1 className="text-center text-2xl font-bold mb-4">LEXIA会計システム</h1>
+        <h1 className="text-center text-2xl font-bold mb-4">LEXIA management system</h1>
         <Input
           type="email"
           value={email}

--- a/app/todo/page.tsx
+++ b/app/todo/page.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import DashboardLayout from "@/components/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { supabase, PROJECTS_TABLE } from "@/lib/supabase"
+import { useEffect, useState } from "react"
+import { AddProjectDialog, NewProject } from "@/components/add-project-dialog"
+import { EditProjectDialog } from "@/components/edit-project-dialog"
+import { ProjectProgressTable, ProjectProgressRecord } from "@/components/project-progress-table"
+
+export default function TodoPage() {
+  const [projects, setProjects] = useState<ProjectProgressRecord[]>([])
+  const [editing, setEditing] = useState<ProjectProgressRecord | null>(null)
+
+  useEffect(() => {
+    supabase
+      .from(PROJECTS_TABLE)
+      .select('*')
+      .order('sort_order', { ascending: true })
+      .then(({ data }) => setProjects(data ?? []))
+      .catch(() => setProjects([]))
+  }, [])
+
+  const handleAddProject = async (project: NewProject) => {
+    const nextOrder = projects.reduce((max, p) => Math.max(max, p.sort_order), -1) + 1
+    const { data, error } = await supabase
+      .from(PROJECTS_TABLE)
+      .insert({ ...project, sort_order: nextOrder })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Insert project error:', error.message)
+      return
+    }
+    if (data) setProjects((prev) => [...prev, data as ProjectProgressRecord])
+  }
+
+  const handleUpdateProject = async (project: ProjectProgressRecord) => {
+    const { data } = await supabase
+      .from(PROJECTS_TABLE)
+      .update(project)
+      .eq('id', project.id)
+      .select()
+      .single()
+    if (data)
+      setProjects((prev) =>
+        prev.map((p) => (p.id === project.id ? (data as ProjectProgressRecord) : p))
+      )
+  }
+
+  const handleDeleteProject = async (id: string) => {
+    await supabase.from(PROJECTS_TABLE).delete().eq('id', id)
+    setProjects((prev) => prev.filter((p) => p.id !== id))
+  }
+
+  const moveProject = async (id: string, direction: "up" | "down") => {
+    let updates: { id: string; sort_order: number }[] = []
+    setProjects((prev) => {
+      const idx = prev.findIndex((p) => p.id === id)
+      if (idx === -1) return prev
+      const swapIdx = direction === "up" ? idx - 1 : idx + 1
+      if (swapIdx < 0 || swapIdx >= prev.length) return prev
+      const newProjects = [...prev]
+      ;[newProjects[idx], newProjects[swapIdx]] = [newProjects[swapIdx], newProjects[idx]]
+      newProjects.forEach((p, i) => {
+        p.sort_order = i
+      })
+      updates = newProjects.map((p) => ({ id: p.id, sort_order: p.sort_order }))
+      return newProjects
+    })
+    if (updates.length) {
+      await supabase.from(PROJECTS_TABLE).upsert(updates)
+    }
+  }
+
+  return (
+    <DashboardLayout>
+      <h1 className="mb-6 text-2xl font-bold">Todo</h1>
+      <Card>
+        <CardHeader className="flex items-center justify-between">
+          <CardTitle>Todo</CardTitle>
+          <AddProjectDialog onAdd={handleAddProject} className="ml-auto" />
+        </CardHeader>
+        <CardContent>
+          <ProjectProgressTable
+            projects={projects}
+            onEdit={(p) => setEditing(p)}
+            onDelete={handleDeleteProject}
+            onUpdate={handleUpdateProject}
+            onMove={(id, dir) => moveProject(id, dir)}
+          />
+        </CardContent>
+      </Card>
+      {editing && (
+        <EditProjectDialog
+          project={editing}
+          onEdit={(p) => {
+            handleUpdateProject(p)
+            setEditing(null)
+          }}
+          open={true}
+          onOpenChange={(v) => !v && setEditing(null)}
+        />
+      )}
+    </DashboardLayout>
+  )
+}
+

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -18,6 +18,7 @@ import {
   Settings,
   Wallet,
   Calculator,
+  ListTodo,
 } from "lucide-react"
 
 interface DashboardLayoutProps {
@@ -43,7 +44,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       <header className="flex items-center h-16 gap-2 border-b px-4 lg:hidden">
         <MobileNav />
         <Wallet className="h-6 w-6" />
-        <span className="font-bold">LEXIA会計システム</span>
+        <span className="font-bold">LEXIA management system</span>
       </header>
       <div
         className={`grid transition-[grid-template-columns] duration-200 [grid-template-columns:1fr] ${
@@ -65,7 +66,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               <span className="sr-only">Close Sidebar</span>
             </Button>
             <Wallet className="h-6 w-6" />
-            <span className="font-bold">LEXIA会計システム</span>
+            <span className="font-bold">LEXIA management system</span>
           </div>
           <nav className="space-y-2 px-2">
             <Button asChild variant="ghost" className="w-full justify-start gap-2">
@@ -84,6 +85,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               <Link href="/kgi-kpi">
                 <BarChart3 className="h-4 w-4" />
                 KGI/KPI
+              </Link>
+            </Button>
+            <Button asChild variant="ghost" className="w-full justify-start gap-2">
+              <Link href="/todo">
+                <ListTodo className="h-4 w-4" />
+                Todo
               </Link>
             </Button>
             <Button asChild variant="ghost" className="w-full justify-start gap-2">

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -20,6 +20,7 @@ import {
   Settings,
   Wallet,
   Calculator,
+  ListTodo,
 } from "lucide-react"
 
 export function MobileNav() {
@@ -33,7 +34,7 @@ export function MobileNav() {
       <SheetContent side="left" className="w-64 p-0">
         <div className="flex h-16 items-center gap-2 border-b px-6">
           <Wallet className="h-6 w-6" />
-          <span className="font-bold">LEXIA会計システム</span>
+          <span className="font-bold">LEXIA management system</span>
         </div>
         <nav className="space-y-2 px-2">
           <Button asChild variant="ghost" className="w-full justify-start gap-2">
@@ -52,6 +53,12 @@ export function MobileNav() {
             <Link href="/kgi-kpi">
               <BarChart3 className="h-4 w-4" />
               KGI/KPI
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" className="w-full justify-start gap-2">
+            <Link href="/todo">
+              <ListTodo className="h-4 w-4" />
+              Todo
             </Link>
           </Button>
           <Button asChild variant="ghost" className="w-full justify-start gap-2">


### PR DESCRIPTION
## Summary
- introduce `/todo` page with project progress management
- move sidebar link to Todo page
- rename site to **LEXIA management system**
- adjust login page and README
- remove project table from KGI/KPI page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686372625c748331bb5682f38587177e