### PR TITLE
Add calendar and gantt chart with extra statuses

### DIFF
--- a/app/todo/page.tsx
+++ b/app/todo/page.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState, useMemo } from "react"
 import { AddProjectDialog, NewProject } from "@/components/add-project-dialog"
 import { EditProjectDialog } from "@/components/edit-project-dialog"
 import { ProjectProgressTable, ProjectProgressRecord } from "@/components/project-progress-table"
+import ProjectCalendar from "@/components/project-calendar"
+import ProjectGanttChart from "@/components/project-gantt-chart"
 import type { RecordItem } from "@/components/vault-table"
 import { formatNumber } from "@/lib/utils"
 
@@ -186,6 +188,24 @@ export default function TodoPage() {
           {predictedWithProjects < kgiTarget && (
             <p className="mt-2 text-sm text-destructive">目標未達の可能性があります。</p>
           )}
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>スケジュールカレンダー</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ProjectCalendar projects={projects} />
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>簡易ガントチャート</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ProjectGanttChart projects={projects} />
         </CardContent>
       </Card>
 

--- a/components/add-project-dialog.tsx
+++ b/components/add-project-dialog.tsx
@@ -32,7 +32,7 @@ export function AddProjectDialog({ onAdd, className }: AddProjectDialogProps) {
   const [form, setForm] = useState<NewProject>({
     project_name: "",
     client_name: "",
-    status: "制作待ち",
+    status: "客先提案",
     due_date: new Date().toISOString().slice(0, 10),
     unit_price: 0,
   })
@@ -47,7 +47,7 @@ export function AddProjectDialog({ onAdd, className }: AddProjectDialogProps) {
     setForm({
       project_name: "",
       client_name: "",
-      status: "制作待ち",
+      status: "客先提案",
       due_date: new Date().toISOString().slice(0, 10),
       unit_price: 0,
     })
@@ -77,8 +77,11 @@ export function AddProjectDialog({ onAdd, className }: AddProjectDialogProps) {
               <SelectValue placeholder="進捗" />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="客先提案">客先提案</SelectItem>
+              <SelectItem value="客先待ち">客先待ち</SelectItem>
               <SelectItem value="制作待ち">制作待ち</SelectItem>
               <SelectItem value="進行中">進行中</SelectItem>
+              <SelectItem value="納品済み">納品済み</SelectItem>
               <SelectItem value="完了">完了</SelectItem>
             </SelectContent>
           </Select>

--- a/components/edit-project-dialog.tsx
+++ b/components/edit-project-dialog.tsx
@@ -79,8 +79,11 @@ export function EditProjectDialog({ project, onEdit, open = false, onOpenChange,
               <SelectValue placeholder="進捗" />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="客先提案">客先提案</SelectItem>
+              <SelectItem value="客先待ち">客先待ち</SelectItem>
               <SelectItem value="制作待ち">制作待ち</SelectItem>
               <SelectItem value="進行中">進行中</SelectItem>
+              <SelectItem value="納品済み">納品済み</SelectItem>
               <SelectItem value="完了">完了</SelectItem>
             </SelectContent>
           </Select>

--- a/components/project-calendar.tsx
+++ b/components/project-calendar.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useMemo } from "react"
+import Calendar from "react-calendar"
+import 'react-calendar/dist/Calendar.css'
+import type { ProjectProgressRecord } from "./project-progress-table"
+import { format } from "date-fns"
+
+interface ProjectCalendarProps {
+  projects: ProjectProgressRecord[]
+}
+
+export default function ProjectCalendar({ projects }: ProjectCalendarProps) {
+  const dateMap = useMemo(() => {
+    const map: Record<string, ProjectProgressRecord[]> = {}
+    projects.forEach((p) => {
+      const key = p.due_date
+      if (!map[key]) map[key] = []
+      map[key].push(p)
+    })
+    return map
+  }, [projects])
+
+  return (
+    <Calendar
+      tileContent={({ date, view }) => {
+        if (view !== 'month') return null
+        const key = format(date, 'yyyy-MM-dd')
+        const list = dateMap[key]
+        if (!list) return null
+        return (
+          <ul className="mt-1 space-y-1">
+            {list.map((p) => (
+              <li key={p.id} className="text-[10px] truncate">
+                {p.project_name}
+              </li>
+            ))}
+          </ul>
+        )
+      }}
+    />
+  )
+}

--- a/components/project-gantt-chart.tsx
+++ b/components/project-gantt-chart.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { differenceInDays, format } from 'date-fns'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+import type { ProjectProgressRecord } from './project-progress-table'
+
+interface ProjectGanttChartProps {
+  projects: ProjectProgressRecord[]
+}
+
+export default function ProjectGanttChart({ projects }: ProjectGanttChartProps) {
+  const now = new Date()
+  const data = projects.map(p => ({
+    name: p.project_name,
+    days: Math.max(differenceInDays(new Date(p.due_date), now), 0)
+  }))
+  return (
+    <div className="h-[300px] w-full max-w-full overflow-hidden">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart layout="vertical" data={data} margin={{ left: 50 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" label={{ value: '残日数', position: 'insideBottomRight', offset: -5 }} />
+          <YAxis dataKey="name" type="category" width={100} />
+          <Tooltip formatter={(v) => `${v}日`} />
+          <Bar dataKey="days" fill="hsl(var(--primary))" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/components/project-progress-table.tsx
+++ b/components/project-progress-table.tsx
@@ -40,8 +40,11 @@ interface ProjectProgressTableProps {
 
 export function ProjectProgressTable({ projects, onEdit, onDelete, onUpdate, onMove }: ProjectProgressTableProps) {
   const statusMap: Record<string, number> = {
-    "制作待ち": 0,
-    "進行中": 50,
+    "客先提案": 0,
+    "客先待ち": 20,
+    "制作待ち": 40,
+    "進行中": 60,
+    "納品済み": 80,
     "完了": 100,
   }
 
@@ -121,8 +124,11 @@ export function ProjectProgressTable({ projects, onEdit, onDelete, onUpdate, onM
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value="客先提案">客先提案</SelectItem>
+                      <SelectItem value="客先待ち">客先待ち</SelectItem>
                       <SelectItem value="制作待ち">制作待ち</SelectItem>
                       <SelectItem value="進行中">進行中</SelectItem>
+                      <SelectItem value="納品済み">納品済み</SelectItem>
                       <SelectItem value="完了">完了</SelectItem>
                     </SelectContent>
                   </Select>

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "papaparse": "latest",
     "path": "latest",
     "react": "^19",
+    "react-calendar": "^4",
     "react-day-picker": "latest",
     "react-dom": "^19",
     "react-hook-form": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       react:
         specifier: ^19
         version: 19.0.0
+      react-calendar:
+        specifier: ^4
+        version: 4.8.0(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-day-picker:
         specifier: latest
         version: 9.7.0(react@19.0.0)
@@ -1131,6 +1134,9 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@wojtekmaj/date-utils@1.5.1':
+    resolution: {integrity: sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1382,6 +1388,9 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-user-locale@2.3.2:
+    resolution: {integrity: sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1456,12 +1465,19 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -1471,6 +1487,14 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  map-age-cleaner@0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
+
+  mem@8.1.1:
+    resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
+    engines: {node: '>=10'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1478,6 +1502,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mimic-fn@3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -1540,6 +1568,10 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  p-defer@1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1625,8 +1657,21 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-calendar@4.8.0:
+    resolution: {integrity: sha512-qFgwo+p58sgv1QYMI1oGNaop90eJVKuHTZ3ZgBfrrpUb+9cAexxsKat0sAszgsizPMVo7vOXedV7Lqa0GQGMvA==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-day-picker@9.7.0:
     resolution: {integrity: sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==}
@@ -1644,6 +1689,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -1906,6 +1954,9 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2902,6 +2953,8 @@ snapshots:
     dependencies:
       '@types/node': 22.0.0
 
+  '@wojtekmaj/date-utils@1.5.1': {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -3135,6 +3188,10 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  get-user-locale@2.3.2:
+    dependencies:
+      mem: 8.1.1
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3202,9 +3259,15 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-tokens@4.0.0: {}
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
 
@@ -3212,12 +3275,23 @@ snapshots:
     dependencies:
       react: 19.0.0
 
+  map-age-cleaner@0.1.3:
+    dependencies:
+      p-defer: 1.0.0
+
+  mem@8.1.1:
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 3.1.0
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mimic-fn@3.1.0: {}
 
   minimatch@9.0.5:
     dependencies:
@@ -3272,6 +3346,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  p-defer@1.0.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -3344,7 +3420,25 @@ snapshots:
 
   process@0.11.10: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   queue-microtask@1.2.3: {}
+
+  react-calendar@4.8.0(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@wojtekmaj/date-utils': 1.5.1
+      clsx: 2.1.1
+      get-user-locale: 2.3.2
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      warning: 4.0.3
+    optionalDependencies:
+      '@types/react': 19.0.0
 
   react-day-picker@9.7.0(react@19.0.0):
     dependencies:
@@ -3361,6 +3455,8 @@ snapshots:
   react-hook-form@7.59.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
@@ -3659,6 +3755,10 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- expand project status options
- display due dates on a calendar
- add a simple gantt-style chart

## Testing
- `pnpm lint` *(fails: asks interactive questions)*

------
https://chatgpt.com/codex/tasks/task_e_68638c7600e88331a73113fd83d5b65a