### PR TITLE
Add reservation mockup

### DIFF
--- a/app/reservation/admin/page.tsx
+++ b/app/reservation/admin/page.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import DashboardLayout from "@/components/dashboard-layout"
+import { supabase, BOOKINGS_TABLE } from "@/lib/supabase"
+import type { Booking } from "@/lib/types"
+import { Card } from "@/components/ui/card"
+
+export default function ReservationAdminPage() {
+  const [bookings, setBookings] = useState<Booking[]>([])
+
+  useEffect(() => {
+    supabase
+      .from(BOOKINGS_TABLE)
+      .select("*")
+      .order("appointment_date", { ascending: true })
+      .then(({ data }) => setBookings(data ?? []))
+      .catch(() => setBookings([]))
+  }, [])
+
+  return (
+    <DashboardLayout>
+      <h1 className="text-2xl font-bold mb-6">予約管理</h1>
+      <div className="space-y-2">
+        {bookings.map((b) => (
+          <Card key={b.id} className="p-4">
+            <div className="font-semibold">
+              {b.appointment_date} {b.appointment_time} / {b.patient_name}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {b.phone} / {b.email}
+            </div>
+            {b.notes && <div className="text-sm mt-1">{b.notes}</div>}
+          </Card>
+        ))}
+        {bookings.length === 0 && <p className="text-sm">予約はありません</p>}
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/reservation/page.tsx
+++ b/app/reservation/page.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import DashboardLayout from "@/components/dashboard-layout"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { supabase, BOOKINGS_TABLE } from "@/lib/supabase"
+import Link from "next/link"
+
+const TIMES = [
+  "11:00",
+  "12:00",
+  "13:00",
+  "14:00",
+  "15:00",
+  "16:00",
+  "17:00",
+  "18:00",
+  "19:00",
+  "20:00",
+]
+
+export default function ReservationPage() {
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [bookings, setBookings] = useState<any[]>([])
+  const [selectedTime, setSelectedTime] = useState<string | null>(null)
+  const [form, setForm] = useState({
+    name: "",
+    phone: "",
+    email: "",
+    notes: "",
+  })
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase
+      .from(BOOKINGS_TABLE)
+      .select("*")
+      .eq("appointment_date", date)
+      .then(({ data }) => setBookings(data ?? []))
+  }, [date])
+
+  const handleSubmit = async () => {
+    if (!selectedTime) return
+    const { error } = await supabase.from(BOOKINGS_TABLE).insert({
+      patient_name: form.name,
+      phone: form.phone,
+      email: form.email,
+      appointment_date: date,
+      appointment_time: selectedTime,
+      notes: form.notes,
+      status: "pending",
+    })
+    if (error) {
+      setMessage(error.message)
+    } else {
+      setMessage("予約を受け付けました")
+      setSelectedTime(null)
+      setForm({ name: "", phone: "", email: "", notes: "" })
+      supabase
+        .from(BOOKINGS_TABLE)
+        .select("*")
+        .eq("appointment_date", date)
+        .then(({ data }) => setBookings(data ?? []))
+    }
+  }
+
+  return (
+    <DashboardLayout>
+      <h1 className="text-2xl font-bold mb-4">予約画面</h1>
+      <div className="mb-4 max-w-xs">
+        <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+      </div>
+      <table className="w-full border mb-6 text-center">
+        <tbody>
+          {TIMES.map((t) => {
+            const booked = bookings.some((b) => b.appointment_time === t)
+            return (
+              <tr key={t} className="border-b">
+                <td className="p-2">{t}</td>
+                <td className="p-2">
+                  {booked ? (
+                    "×"
+                  ) : (
+                    <button onClick={() => setSelectedTime(t)} className="text-lg">
+                      〇
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {selectedTime && (
+        <div className="grid gap-4 max-w-md mb-4">
+          <h2 className="font-semibold">
+            {date} {selectedTime} の予約
+          </h2>
+          <div className="grid gap-2">
+            <label className="text-sm">お名前</label>
+            <Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-sm">電話番号</label>
+            <Input value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-sm">メール</label>
+            <Input type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-sm">備考</label>
+            <Textarea value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} />
+          </div>
+          <Button onClick={handleSubmit}>予約する</Button>
+          {message && <p className="text-sm text-destructive">{message}</p>}
+        </div>
+      )}
+      <Link href="/reservation/admin" className="text-sm underline">
+        管理画面へ
+      </Link>
+    </DashboardLayout>
+  )
+}

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react"
 import { useState } from "react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { MobileNav } from "@/components/mobile-nav"
 import LogoutButton from "@/components/LogoutButton"
@@ -28,6 +29,7 @@ interface DashboardLayoutProps {
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true)
+  const pathname = usePathname()
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -101,11 +103,19 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               </Link>
             </Button>
             <Button asChild variant="ghost" className="w-full justify-start gap-2">
-              <Link href="/reservation-test">
+              <Link href="/reservation">
                 <CalendarClock className="h-4 w-4" />
-                予約テスト
+                予約画面
               </Link>
             </Button>
+            {pathname?.startsWith("/reservation") && (
+              <Button asChild variant="ghost" className="w-full justify-start gap-2">
+                <Link href="/reservation/admin">
+                  <LayoutDashboard className="h-4 w-4" />
+                  管理画面
+                </Link>
+              </Button>
+            )}
             <Button asChild variant="ghost" className="w-full justify-start gap-2">
               <Link href="/web-dev">
                 <BookOpen className="h-4 w-4" />

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import LogoutButton from "@/components/LogoutButton"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import {
   Sheet,
   SheetContent,
@@ -24,6 +25,7 @@ import {
 } from "lucide-react"
 
 export function MobileNav() {
+  const pathname = usePathname()
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -67,6 +69,20 @@ export function MobileNav() {
               WEB開発手法
             </Link>
           </Button>
+          <Button asChild variant="ghost" className="w-full justify-start gap-2">
+            <Link href="/reservation">
+              <CalendarClock className="h-4 w-4" />
+              予約画面
+            </Link>
+          </Button>
+          {pathname?.startsWith("/reservation") && (
+            <Button asChild variant="ghost" className="w-full justify-start gap-2">
+              <Link href="/reservation/admin">
+                <LayoutDashboard className="h-4 w-4" />
+                管理画面
+              </Link>
+            </Button>
+          )}
           <Button asChild variant="ghost" className="w-full justify-start gap-2">
             <Link href="/settings">
               <Settings className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- create new reservation screens with Supabase integration
- show admin link when viewing reservation pages
- add reservation links to sidebars

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68675d473a80833180074cb356d2fdd6