### PR TITLE
Fix mobile reservation table layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,8 +12,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ja" suppressHydrationWarning className="overflow-x-hidden">
-      <body className={`${inter.className} overflow-x-hidden`}>
+    <html lang="ja" suppressHydrationWarning>
+      <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <AuthProvider>{children}</AuthProvider>
         </ThemeProvider>

--- a/app/reservation/page.tsx
+++ b/app/reservation/page.tsx
@@ -151,12 +151,12 @@ export default function ReservationPage() {
       </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full border mb-6 text-center">
+        <table className="w-full border mb-6 text-center whitespace-nowrap">
           <thead>
             <tr className="border-b">
-              <th className="p-2 border-r w-24"></th> {/* Empty header cell */}
+              <th className="p-2 border-r w-24 h-12"></th> {/* Empty header cell */}
               {dateRange.map((day) => (
-                <th key={day.toString()} className="p-2 border-r w-24">
+                <th key={day.toString()} className="p-2 border-r w-24 h-12">
                   {format(day, "M/d (eee)", { locale: ja })}
                 </th>
               ))}
@@ -165,16 +165,16 @@ export default function ReservationPage() {
         <tbody>
           {TIMES.map((time) => (
             <tr key={time} className="border-b">
-              <td className="p-2 border-r">{time}</td>
+              <td className="p-2 border-r w-24 h-12">{time}</td>
               {dateRange.map((day) => {
                 const dayStr = format(day, "yyyy-MM-dd")
                 const booked = bookings.some(
                   (b) => b.appointment_date === dayStr && b.appointment_time === time,
                 )
                 return (
-                  <td key={day.toString() + time} className="p-2 border-r">
+                  <td key={day.toString() + time} className="p-2 border-r w-24 h-12">
                     {booked ? (
-                      <span className="text-red-500">×</span>
+                      <span className="text-red-500 inline-block w-8 h-8 flex items-center justify-center">×</span>
                     ) : (
                       <button
                         onClick={() => setSelectedSlot({ date: dayStr, time })}


### PR DESCRIPTION
## Summary
- remove global `overflow-x-hidden` to allow horizontal scrolling
- adjust reservation table to scroll and display days in Japanese
- unify cell sizing for better appearance

## Testing
- `pnpm lint` *(fails: ESLint configuration prompts)*
- `pnpm build` *(fails: supabaseUrl is required)*
- `pnpm tsc --noEmit` *(fails: temporary_page_content.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867edd0c0c48331a8b40a6ec619b151