### PR TITLE
Add basic input validation with zod

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, FormEvent } from "react"
+import { z } from "zod"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/context/AuthContext"
 import { Button } from "@/components/ui/button"
@@ -17,11 +18,24 @@ export default function LoginPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+
+    const schema = z.object({
+      email: z.string().email(),
+      password: z.string().min(8),
+    })
+
+    const result = schema.safeParse({ email, password })
+    if (!result.success) {
+      setError("入力が正しくありません")
+      return
+    }
+
     try {
       await signIn(email, password)
       router.push('/')
     } catch (err: any) {
-      setError(err.message)
+      console.error(err)
+      setError("ログインに失敗しました")
     }
   }
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, FormEvent } from "react"
+import { z } from "zod"
 import { useAuth } from "@/context/AuthContext"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -23,11 +24,24 @@ export default function SignUpPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+
+    const schema = z.object({
+      email: z.string().email(),
+      password: z.string().min(8),
+    })
+
+    const result = schema.safeParse({ email, password })
+    if (!result.success) {
+      setError("入力が正しくありません")
+      return
+    }
+
     try {
       await signUp(email, password)
       setOpen(true)
     } catch (err: any) {
-      setError(err.message)
+      console.error(err)
+      setError("登録に失敗しました")
     }
   }
 

--- a/components/add-project-dialog.tsx
+++ b/components/add-project-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { z } from "zod"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -42,7 +43,21 @@ export function AddProjectDialog({ onAdd, className }: AddProjectDialogProps) {
   }
 
   const handleSubmit = () => {
-    onAdd({ ...form, unit_price: Number(form.unit_price) })
+    const schema = z.object({
+      project_name: z.string().nonempty(),
+      client_name: z.string().nonempty(),
+      status: z.string().nonempty(),
+      due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      unit_price: z.preprocess((v) => Number(v), z.number().nonnegative()),
+    })
+
+    const result = schema.safeParse(form)
+    if (!result.success) {
+      alert("入力内容を確認してください")
+      return
+    }
+
+    onAdd(result.data)
     setOpen(false)
     setForm({
       project_name: "",

--- a/components/add-record-dialog.tsx
+++ b/components/add-record-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, ChangeEvent, useEffect } from "react"
+import { z } from "zod"
 import Papa from "papaparse"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
@@ -54,9 +55,24 @@ export function AddRecordDialog({ onAdd, onImport }: AddRecordDialogProps) {
   }
 
   const handleSubmit = () => {
+    const schema = z.object({
+      category: z.enum(["Income", "Expense"]),
+      type: z.string().nonempty(),
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      amount: z.preprocess((v) => Number(v), z.number().nonnegative()),
+      client: z.string().optional(),
+      item: z.string().optional(),
+      notes: z.string().optional(),
+    })
+
+    const result = schema.safeParse(form)
+    if (!result.success) {
+      alert("入力内容を確認してください")
+      return
+    }
+
     const payload = {
-      ...form,
-      amount: Number(form.amount),
+      ...result.data,
     }
     onAdd(payload)
     setOpen(false)


### PR DESCRIPTION
## Summary
- add zod validation for login, signup and dialog forms
- show generic error messages instead of raw exceptions

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e598400a88331938db5d8a964c023